### PR TITLE
First init of the container does not work

### DIFF
--- a/domain.ldif
+++ b/domain.ldif
@@ -4,22 +4,22 @@ replace: olcAccess
 olcAccess: {0}to * by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth"
   read by dn.base="cn=Manager,dc=tuleap,dc=local" read by * none
 
-dn: olcDatabase={2}bdb,cn=config
+dn: olcDatabase={2}hdb,cn=config
 changetype: modify
 replace: olcSuffix
 olcSuffix: dc=tuleap,dc=local
 
-dn: olcDatabase={2}bdb,cn=config
+dn: olcDatabase={2}hdb,cn=config
 changetype: modify
 replace: olcRootDN
 olcRootDN: cn=Manager,dc=tuleap,dc=local
 
-dn: olcDatabase={2}bdb,cn=config
+dn: olcDatabase={2}hdb,cn=config
 changetype: modify
 add: olcRootPW
 olcRootPW: %LDAP_MANAGER_PASSWORD%
 
-dn: olcDatabase={2}bdb,cn=config
+dn: olcDatabase={2}hdb,cn=config
 add: olcAccess
 olcAccess: {0}to attrs=userPassword,shadowLastChange by
   dn="cn=Manager,dc=tuleap,dc=local" write by anonymous auth by self write by * none

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # Changing the open file descriptors limit, otherwise slapd memory
 # consumption is crazy
@@ -9,14 +9,15 @@ ulimit -n 1024
 
 if [ ! -f /data/lib/ldap/DB_CONFIG ]; then
     if [ -z "$LDAP_ROOT_PASSWORD" -o -z "$LDAP_MANAGER_PASSWORD" ]; then
-	echo "Need LDAP_ROOT_PASSWORD and LDAP_MANAGER_PASSWORD"
-	exit
+        echo "Need LDAP_ROOT_PASSWORD and LDAP_MANAGER_PASSWORD"
+        exit
     fi
 
     cp /usr/share/openldap-servers/DB_CONFIG.example /var/lib/ldap/DB_CONFIG
     chown ldap. /var/lib/ldap/DB_CONFIG
 
-    service slapd start
+    /usr/sbin/slapd -h "ldap:/// ldaps:/// ldapi:///" -u ldap -d $DEBUG_LEVEL &
+    slapd_pid=$!
     sleep 3
 
     ROOT_PWD=$(slappasswd -s $LDAP_ROOT_PASSWORD)
@@ -24,14 +25,17 @@ if [ ! -f /data/lib/ldap/DB_CONFIG ]; then
     sed -i "s+%LDAP_ROOT_PASSWORD%+${ROOT_PWD//+/\\+}+" /root/manager.ldif
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /root/manager.ldif
 
+    ldapadd -Y EXTERNAL -H ldapi:/// -D "cn=config" -f /etc/openldap/schema/cosine.ldif
+    ldapadd -Y EXTERNAL -H ldapi:/// -D "cn=config" -f /etc/openldap/schema/nis.ldif
+    ldapadd -Y EXTERNAL -H ldapi:/// -D "cn=config" -f /etc/openldap/schema/inetorgperson.ldif
     MANAGER_PWD=$(slappasswd -s $LDAP_MANAGER_PASSWORD)
     sed -i "s+%LDAP_MANAGER_PASSWORD%+${MANAGER_PWD//+/\\+}+" /root/domain.ldif
     ldapmodify -Y EXTERNAL -H ldapi:/// -f /root/domain.ldif
 
     ldapadd -x -D cn=Manager,dc=tuleap,dc=local -w $LDAP_MANAGER_PASSWORD -f /root/base.ldif
 
-    service slapd stop
-    sleep 3
+    kill "$slapd_pid"
+    wait "$slapd_pid"
 
     mkdir /data/lib /data/etc
     cp -ar /var/lib/ldap /data/lib


### PR DESCRIPTION
Since the upgrade of this image to CentOS 7 in 28a09a33ece7d29932b0379be6cffa7694a3a438 the container crashes when it is started with an empty DB.

This can be tested with the automated tests of the distributed Tuleap setup in the main Tuleap code base (use `make tests_cypress_distlp` after having modified the Docker Compose file to use your locally built image).