### PR TITLE
chore: Use Rocky Linux 9 as the base image

### DIFF
--- a/DB_CONFIG
+++ b/DB_CONFIG
@@ -1,0 +1,28 @@
+# $OpenLDAP$
+# Example DB_CONFIG file for use with slapd(8) BDB/HDB databases.
+#
+# See the Oracle Berkeley DB documentation
+#   <http://www.oracle.com/technology/documentation/berkeley-db/db/ref/env/db_config.html>
+# for detail description of DB_CONFIG syntax and semantics.
+#
+# Hints can also be found in the OpenLDAP Software FAQ
+#	<http://www.openldap.org/faq/index.cgi?file=2>
+# in particular:
+#   <http://www.openldap.org/faq/index.cgi?file=1075>
+
+# Note: most DB_CONFIG settings will take effect only upon rebuilding
+# the DB environment.
+
+# one 0.25 GB cache
+set_cachesize 0 268435456 1
+
+# Data Directory
+#set_data_dir db
+
+# Transaction Log settings
+set_lg_regionmax 262144
+set_lg_bsize 2097152
+#set_lg_dir logs
+
+# Note: special DB_CONFIG flags are no longer needed for "quick"
+# slapadd(8) or slapindex(8) access (see their -q option).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 # Dockerfile to build a ldap server for DEVELOPMENT #
 # None of the following is meant for production, esp. from a security pov #
 
-## Use the official docker centos distribution ##
-FROM centos:7
-
-## Get some karma ##
-MAINTAINER Manuel Vacelet, manuel.vacelet@enalean.com
+FROM rockylinux:9
 
 # See possible debug levels in man page (loglevel): http://linux.die.net/man/5/slapd.conf
 ENV DEBUG_LEVEL=256
@@ -14,8 +10,8 @@ VOLUME [ "/data" ]
 
 # Update to last version
 
-RUN yum -y install openldap-servers openldap-clients && \
-    yum clean all
+RUN dnf install -y epel-release && dnf -y install openldap-servers openldap-clients libdb-utils && \
+    dnf clean all
 
 COPY . /root
 

--- a/domain.ldif
+++ b/domain.ldif
@@ -4,22 +4,22 @@ replace: olcAccess
 olcAccess: {0}to * by dn.base="gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth"
   read by dn.base="cn=Manager,dc=tuleap,dc=local" read by * none
 
-dn: olcDatabase={2}hdb,cn=config
+dn: olcDatabase={2}mdb,cn=config
 changetype: modify
 replace: olcSuffix
 olcSuffix: dc=tuleap,dc=local
 
-dn: olcDatabase={2}hdb,cn=config
+dn: olcDatabase={2}mdb,cn=config
 changetype: modify
 replace: olcRootDN
 olcRootDN: cn=Manager,dc=tuleap,dc=local
 
-dn: olcDatabase={2}hdb,cn=config
+dn: olcDatabase={2}mdb,cn=config
 changetype: modify
 add: olcRootPW
 olcRootPW: %LDAP_MANAGER_PASSWORD%
 
-dn: olcDatabase={2}hdb,cn=config
+dn: olcDatabase={2}mdb,cn=config
 add: olcAccess
 olcAccess: {0}to attrs=userPassword,shadowLastChange by
   dn="cn=Manager,dc=tuleap,dc=local" write by anonymous auth by self write by * none


### PR DESCRIPTION
Note that the data are in a different directory, upgrading from the version used in EL7 to the version used in Rocky Linux 9 is not directly possible without some manual changes :/

It is probably good enough, devs can use `./tools/utils/tuleap-dev.php ldap:*` if they need to add back some data into it.